### PR TITLE
Progress for OMP import #62.

### DIFF
--- a/static/tools/heimpt.py
+++ b/static/tools/heimpt.py
@@ -123,7 +123,7 @@ class MPT(Debuggable):
           A dictionary, where keys are names of command-line elements  such as  and values are theparsed values of those
           elements.
         """
-        return docopt(__doc__, version='heiMPT 0.0.1')
+        return docopt(__doc__, version='heiMPT 0.0.1', options_first=True)
 
 
     def get_module_name(self):

--- a/static/tools/plugins/import/omp/settings.example.json
+++ b/static/tools/plugins/import/omp/settings.example.json
@@ -6,11 +6,12 @@
   "project-template": "configurations/01_wintz.bits.json",
   "project-output": "configurations/import/omp",
   "press": 1,
-  "file-stage": 2,
+  "file-stage": 11,
   "file-types": [
     "application/vnd.oasis.opendocument.text",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   ],
   "genre": 3,
-  "submission": 234
+  "submission": 234,
+  "skip-submission-without-files": false
 }


### PR DESCRIPTION
omp.py:
Add command line options for importing all submissions of a press.
Added setting to skip import of submissions without matching submission files (skip-submission-without-files).
Fixed unicode error in formatting of book-title.
Added check for existing isbn.
Added more contrib-types to dictionary, ignored unknown user groups of contributors.
Added unicode conversion for contributor names.
heimpt.py:
Changed parsing of command line arguments with docopt to use options_first.